### PR TITLE
Fix repository method for administrator company lookup

### DIFF
--- a/service/src/main/java/com/legipilot/service/core/company/infra/out/JpaCompanyRepository.java
+++ b/service/src/main/java/com/legipilot/service/core/company/infra/out/JpaCompanyRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @Repository
 public interface JpaCompanyRepository extends JpaRepository<CompanyDto, UUID> {
 
-    List<CompanyDto> getAllByAdministratorsId(UUID administratorId);
+    List<CompanyDto> getAllByAdministratorAssociationsAdministratorId(UUID administratorId);
 
     List<CompanyDto> findByAdministratorAssociations_AdministratorId(UUID administratorId);
 


### PR DESCRIPTION
## Summary
- correct the derived query name used to load companies by administrator association

## Testing
- mvn test *(fails: unable to download dependencies from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68de4fe12bf48325841785563768a00c